### PR TITLE
fix: el/mu PFlow 

### DIFF
--- a/SCD/config/config_Wlep.json
+++ b/SCD/config/config_Wlep.json
@@ -1,8 +1,8 @@
 {
-    "Output_file_path":"./hadron.root",
-    "Script_file_path":"macro/Pythia8/ChargedPion_monochromatic_isotropic.in",
+    "Output_file_path":"./Wlep.root",
+    "Script_file_path":"macro/Pythia8/W.in",
     "Type_of_running": "Standard",
-    "run_hadron_test" : true,
+    "run_hadron_test" : false,
     "Save_truth_particle_graph": false,
     "Skip_unuseable_tracks": false,
     "Geometry_definition":

--- a/SCD/include/Particle_flow_var.hh
+++ b/SCD/include/Particle_flow_var.hh
@@ -19,7 +19,11 @@ public:
     Particle_flow_var(Topo_clust topo_clust);
     ~Particle_flow_var();
     void subt_cell(Cell &cell, float fraction);
-    //if charge is 0, then labele coresonds to topo_clust, if not then to track
+    //if not isTrack && charge is not 0, then PFlow is TC from electron
+    //if not isTrack && charge is 0, then PFlow is TC 
+    //else isTrack, then PFlow is Track
+    //if not isTrack, then label coresonds to topo_clust, if not then to track
+    bool isTrack;
     float charge;
     int label;
     float eta;
@@ -31,6 +35,5 @@ public:
     int truth_link;
 
 };
-
 
 #endif // __PARTICLE_FLOW_VAR_H__

--- a/SCD/include/Topo_clust_var.hh
+++ b/SCD/include/Topo_clust_var.hh
@@ -30,6 +30,7 @@ public:
     float pz;
     int truth_link;
     float cell_energy;
+    int charge;
 
     void add_cell(Cell &cell);
     void subtract_cell(Cell &cell, float fraction);

--- a/SCD/macro/Pythia8/W.in
+++ b/SCD/macro/Pythia8/W.in
@@ -1,0 +1,27 @@
+/generator/select pythia8
+/generator/pythia8/verbose 0
+/generator/pythia8/QuarkGluon 22122212
+
+#setting seed to be able to restore the event in future
+
+/generator/pythia8/read Beams:eCM = 14000.
+/generator/pythia8/read Beams:idA = 2212
+/generator/pythia8/read Beams:idB = 2212
+
+/generator/pythia8/read PartonLevel:ISR = off
+/generator/pythia8/read PartonLevel:FSR = off
+
+#/generator/pythia8/read HiggsSM:ffbar2HW = on              # WH
+#/generator/pythia8/read WeakSingleBoson:ffbar2gmZ = on     # Z
+#/generator/pythia8/read 23:onMode = off                    # Z no decaying    
+#/generator/pythia8/read 23:onIfAny = 1 2 3 4 5             # Z -> qq
+
+/generator/pythia8/read WeakSingleBoson:ffbar2W = on        # W
+/generator/pythia8/read 24:onMode = off                     # W no decaying
+/generator/pythia8/read 24:onIfAny = -11 -13                # W -> lep
+
+/generator/pythia8/init 2212 2212 14000.
+
+/tracking/storeTrajectory 1
+
+/run/beamOn 1000

--- a/SCD/src/Particle_flow_func.cc
+++ b/SCD/src/Particle_flow_func.cc
@@ -64,7 +64,7 @@ Particle_flow_func::Particle_flow_func(std::vector<Track_struct> &track_list, st
 
     for (int itrack = 0; itrack < size_track_list; itrack++)
     {
-        if (track_list.at(itrack).pdgcode!=11 && track_list.at(itrack).Is_Track_Useable() )
+        if (abs(track_list.at(itrack).pdgcode)!=11 && track_list.at(itrack).Is_Track_Useable() )
             pflow_list.emplace_back(track_list.at(itrack));
     }    
 }

--- a/SCD/src/Particle_flow_func.cc
+++ b/SCD/src/Particle_flow_func.cc
@@ -28,21 +28,32 @@ Particle_flow_func::Particle_flow_func(std::vector<Track_struct> &track_list, st
     layer_max = -1;
     int size_track_list = track_list.size();
     Topo_List = topo_list;
-    
+
     for (int itrack = 0; itrack < size_track_list; itrack++)
     {
-        if (track_list.at(itrack).Is_Track_Useable())
+        if ((abs(track_list.at(itrack).pdgcode)!=13) && track_list.at(itrack).Is_Track_Useable())
         {
             track_match_to_topoclusters(track_list.at(itrack));
             if (track_list.at(itrack).Rprime_to_closest_topoclusters.at(0) < delta_Rprime_threshold)
             {
-                layer_max = LHED(track_list.at(itrack), geometry, cells_in_topoclust);
-		track_list.at(itrack).SetLHED( layer_max );
-                recovering_shower_split(track_list.at(itrack));
-                cell_by_cell_subst(track_list.at(itrack));
+                if (abs(track_list.at(itrack).pdgcode)!=11)
+                {
+                    layer_max = LHED(track_list.at(itrack), geometry, cells_in_topoclust);
+                    track_list.at(itrack).SetLHED( layer_max );
+                    recovering_shower_split(track_list.at(itrack));
+                    cell_by_cell_subst(track_list.at(itrack));
+                }
+                else
+                {
+                    for (auto tc_idx : track_list.at(itrack).index_of_closest_topoclusters)
+		    {
+                        Topo_List.at(tc_idx-1).charge = track_list.at(itrack).charge;
+                    }
+                }
             }
         }
     }
+
     for (int itopo = 0; itopo < (int)Topo_List.size(); itopo++)
     {
         if (Topo_List.at(itopo).total_energy > 0)
@@ -53,7 +64,7 @@ Particle_flow_func::Particle_flow_func(std::vector<Track_struct> &track_list, st
 
     for (int itrack = 0; itrack < size_track_list; itrack++)
     {
-        if (track_list.at(itrack).Is_Track_Useable())
+        if (track_list.at(itrack).pdgcode!=11 && track_list.at(itrack).Is_Track_Useable() )
             pflow_list.emplace_back(track_list.at(itrack));
     }    
 }

--- a/SCD/src/Particle_flow_func.cc
+++ b/SCD/src/Particle_flow_func.cc
@@ -31,7 +31,7 @@ Particle_flow_func::Particle_flow_func(std::vector<Track_struct> &track_list, st
     
     for (int itrack = 0; itrack < size_track_list; itrack++)
     {
-        if (((abs(track_list.at(itrack).pdgcode) != 11) || (abs(track_list.at(itrack).pdgcode) != 13) )&& track_list.at(itrack).Is_Track_Useable())
+        if (track_list.at(itrack).Is_Track_Useable())
         {
             track_match_to_topoclusters(track_list.at(itrack));
             if (track_list.at(itrack).Rprime_to_closest_topoclusters.at(0) < delta_Rprime_threshold)
@@ -53,7 +53,7 @@ Particle_flow_func::Particle_flow_func(std::vector<Track_struct> &track_list, st
 
     for (int itrack = 0; itrack < size_track_list; itrack++)
     {
-        if (abs(track_list.at(itrack).pdgcode) != 11 && track_list.at(itrack).Is_Track_Useable())
+        if (track_list.at(itrack).Is_Track_Useable())
             pflow_list.emplace_back(track_list.at(itrack));
     }    
 }

--- a/SCD/src/Particle_flow_var.cc
+++ b/SCD/src/Particle_flow_var.cc
@@ -3,6 +3,7 @@
 
 Particle_flow_var::Particle_flow_var() 
 {
+    isTrack = false;
     charge = 0;
     label  = 0;
     eta = 0;
@@ -16,6 +17,7 @@ Particle_flow_var::Particle_flow_var()
 
 Particle_flow_var::Particle_flow_var(Track_struct track)
 {
+    isTrack = true;
     charge = sgn(track.q_p);
     label  = track.position_in_list;
     float theta = track.theta;
@@ -31,7 +33,8 @@ Particle_flow_var::Particle_flow_var(Track_struct track)
 
 Particle_flow_var::Particle_flow_var(Topo_clust topo_clust)
 {
-    charge = 0;
+    isTrack = false;
+    charge = topo_clust.charge;
     label = topo_clust.label;
     eta = topo_clust.eta_com;
     phi = topo_clust.phi_com;

--- a/SCD/src/Topo_clust_var.cc
+++ b/SCD/src/Topo_clust_var.cc
@@ -9,6 +9,7 @@ Topo_clust::Topo_clust()
     neutral_energy = 0;
     charge_energy = 0;
 
+    charge = 0;
     eta_com = 0;
     phi_com = 0;
     R_com = 0;
@@ -35,6 +36,7 @@ Topo_clust::Topo_clust(int Label, Geometry_definition Geometry)
     neutral_energy = 0;
     charge_energy = 0;
 
+    charge = 0;
     eta_com = 0;
     phi_com = 0;
     R_com = 0;

--- a/SCD/src/Tracks_data.cc
+++ b/SCD/src/Tracks_data.cc
@@ -46,7 +46,7 @@ void Tracks_data::Fill_perigee_var()
         }
         for (int ipflow = 0; ipflow < size_pflow; ipflow++)
         {
-            if ((pflow_pbj.pflow_list.at(ipflow).charge != 0))
+            if ((pflow_pbj.pflow_list.at(ipflow).isTrack))
             {
                 track_pflow_object_idx.at(pflow_pbj.pflow_list.at(ipflow).label) = ipflow;
             }


### PR DESCRIPTION
Particle flow subtraction is not computed for electron and muons. Fix or condition in:

https://github.com/scd-hep/scd-hep/blob/main/SCD/src/Particle_flow_func.cc#L34

and implement an Electron ID introducing "isTrack" flag. Now TopoClusters matched to an electron track are assigned to be charged, i.e. Electron.

Lorenzo 