### PR TITLE
fix: hadron test reference after adjustment of granularity.

### DIFF
--- a/SCD/config/config_hadron_test.json
+++ b/SCD/config/config_hadron_test.json
@@ -49,25 +49,5 @@
         "cluster_negative_energy_cells": false,
         "local_max_seed_energy": 400 
 
-    },
-    "Jet_parameters":
-    {
-        "algorithm": "antikt_algorithm",
-        "radius": 0.6,
-        "recombination_scheme": "E_scheme", 
-        "ptmin": 10000
-    },
-    "Particle_flow":
-    {
-        "S_discriminant_threshold":-1,
-        "E_div_p_threshold": 0.1,
-        "delta_Rprime_threshold": [2.4, 1.25, 0.8],
-        "momentum_delta_Rprime_threshold": [2000, 5000],
-        "factor_sigma_E_div_p_template": 1.25,
-        "Moliere_radius": 0.035
-    },
-    "Fiducial_cuts":
-    {
-        "dR_cut": -1
-    }	
+    }
 }

--- a/SCD/config/config_piZero_test.json
+++ b/SCD/config/config_piZero_test.json
@@ -17,7 +17,7 @@
         "Noise_in_HCAL":[75, 50, 25],
         "Detector_granularity" : 
         {
-            "Number_of_pixels_ECAL": [128,128,128],
+            "Number_of_pixels_ECAL": [256,256,128],
             "Number_of_pixels_HCAL": [64,64,32],
             "Width_of_ECAL_layers_in_X0":  [4,16,2],
             "Width_of_HCAL_layers_in_Lambda_int":  [1.5,4.1,1.8]

--- a/SCD/src/RunTest.cc
+++ b/SCD/src/RunTest.cc
@@ -66,7 +66,7 @@ int RunTest( test_t type ) {
 
     switch ( type ) {
         case kHADRON:
-            mean_expected = 0.57;
+            mean_expected = 0.5;
             std_expected  = 0.23;
             test_name     = "hadron";
             break;


### PR DESCRIPTION
After choosing the correct default granularity in the test configs (in line with the paper), the reference mean reco energy for pi^+ must be adjusted. That's done here.
